### PR TITLE
Disable shadows for scanned scene meshes.

### DIFF
--- a/assets/ar/scene_anchor.gd
+++ b/assets/ar/scene_anchor.gd
@@ -15,4 +15,5 @@ func setup_scene(entity : OpenXRFbSpatialEntity) -> void:
 	var mesh_instance := entity.create_mesh_instance()
 	if mesh_instance:
 		add_child(mesh_instance)
+		mesh_instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 		mesh_instance.material_override = material


### PR DESCRIPTION
This PR disables shadows on scanned AR meshes such as walls and tables.